### PR TITLE
chore: add Cargo.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/
 output.mp4
 output.aac
+Cargo.lock


### PR DESCRIPTION
Noticed this while using the crate—just adding Cargo.lock to .gitignore to avoid accidental commits.
I know some devs might have it in their global gitignore already, but thought it’d help to include
 it here explicitly since this is a library crate.