### PR TITLE
Fix the error:   `CodecInfo` doesn't implement `std::fmt::Display`

### DIFF
--- a/examples/query_codecs/main.rs
+++ b/examples/query_codecs/main.rs
@@ -3,9 +3,9 @@ use ez_ffmpeg::codec::{get_decoders, get_encoders};
 fn main() {
     // Fetch and print all available encoders
     // Encoders are used to convert data into different formats (e.g., encoding video, audio).
-    get_encoders().iter().for_each(|x| println!("{}", x));
+    get_encoders().iter().for_each(|x| println!("{:?}", x));
 
     // Fetch and print all available decoders
     // Decoders are used to decode the input data (e.g., decoding video, audio).
-    get_decoders().iter().for_each(|x| println!("{}", x));
+    get_decoders().iter().for_each(|x| println!("{:?}", x));
 }


### PR DESCRIPTION
Fix the error in the   query_codecs   example:   CodecInfo   doesn't implement   std::fmt::Display  