### PR TITLE
add feature of build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ opengl = ["dep:surfman", "dep:glow", "dep:bytemuck"]
 rtmp = ["dep:rml_rtmp", "dep:slab", "dep:dashmap", "flv"]
 flv = ["dep:bytes", "dep:byteorder"]
 static = ["ffmpeg-next/static"]
+build = ["ffmpeg-next/build"]
 docs-rs = ["async", "opengl", "rtmp", "flv"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -100,7 +100,17 @@ More examples can be found [here][examples].
 - **rtmp:** Includes an embedded RTMP server for local streaming scenarios.
 - **flv:** Provides support for FLV container parsing and handling.
 - **async:** Adds asynchronous functionality (allowing you to `.await` operations).
-- **static:** Enables static linking for FFmpeg libraries (via `ffmpeg-next/static`).
+
+### Port Features
+
+Enables support for features provided by the `ffmpeg-next-sys` crate.
+
+> [!CAUTION]
+> If you encounter build errors related to these features, **please do not create an issue in this repository**.  
+> Instead, report them to the `ffmpeg-next-sys` repository: [https://github.com/zmwangx/rust-ffmpeg-sys](https://github.com/zmwangx/rust-ffmpeg-sys)
+
+- **static**: Enables static linking of FFmpeg libraries (via `ffmpeg-next-sys/static`).
+- **build**: Builds FFmpeg from source and links it statically (via `ffmpeg-next-sys/build`).
 
 ## License
 


### PR DESCRIPTION
## Changed:
- Added the `build` feature to `Cargo.toml`.
- Added a new `### Port Features` section to the README to document features delegated to `ffmpeg-next-sys`.

## Notes
- The new section includes a alert block about where to report build-related issues.
- Would `WARNING` or `CAUTION` be more appropriate for the alert? Or would it be better to remove the alert entirely?