### PR TITLE
fix: resolve aarch64 Linux compilation errors due to unsigned char type and va_list mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
             vcpkg_triplet: arm64-windows
             build_features: async,opengl,wgpu,rtmp,flv,subtitle
             test_features: async,rtmp,flv,subtitle,wgpu
-            test_args: ""
+            test_args: -- --test-threads=1
     env:
       CARGO_BUILD_JOBS: 2
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 # CI for ez-ffmpeg.
 #
-# Every job runs in a two-lane FFmpeg matrix, because the crate supports
+# Linux build and test jobs run on both native GitHub-hosted architectures
+# (x64 and ARM64) in a two-lane FFmpeg matrix, because the crate supports
 # linking either major and the two lanes are provisioned differently:
 #
 #   * ffmpeg 8.1 lane — `--features ffmpeg-sys-next/build`: the sys crate's
@@ -21,6 +22,12 @@
 # (nasm/yasm/clang/pkg-config/zlib). First build per lane compiles FFmpeg
 # (~10-20 min); caches make subsequent runs fast.
 #
+# Native platform coverage outside Linux runs once per GitHub-hosted
+# architecture: Apple Silicon macOS, Windows x64, and Windows ARM64. macOS
+# builds FFmpeg 8.1 from source, while Windows installs FFmpeg 8.1 through the
+# runner's vcpkg checkout. These jobs build every functional non-static feature,
+# compile the corresponding test trees, and run the CPU-only library suite.
+#
 # GPU-dependent code: the `opengl` frame filter needs a real GPU/display and
 # its tests fail headless ("Failed to create Surfman connection"), so the
 # `test` job omits that feature; the `build` job still compiles it (via
@@ -31,7 +38,8 @@
 # `#[cfg(target_os = "macos")]`, so they do not run on Linux.
 #
 # The `build` job (all-features build + a default-features build + clippy) and
-# the `test` job run per FFmpeg lane. Two lanes run once, not per FFmpeg:
+# the `test` job run per Linux architecture and FFmpeg lane. Two specialized
+# jobs run once on Linux x64:
 #
 #   * `docs` — compiles the crate under `--cfg docsrs` (`DOCS_RS=1`), which stubs
 #     ez-ffmpeg's own FFI call sites; the gate catches docsrs-stub compile gaps.
@@ -61,15 +69,27 @@ env:
 
 jobs:
   build:
-    name: Build & Clippy (FFmpeg ${{ matrix.ffmpeg }})
-    runs-on: ubuntu-latest
+    name: Build & Clippy (${{ matrix.arch }}, FFmpeg ${{ matrix.ffmpeg }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - ffmpeg: "8.1"
+          - runner: ubuntu-24.04
+            arch: x64
+            ffmpeg: "8.1"
             ffmpeg-features: "--features ffmpeg-sys-next/build"
-          - ffmpeg: "7.1"
+          - runner: ubuntu-24.04
+            arch: x64
+            ffmpeg: "7.1"
+            ffmpeg-features: ""
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            ffmpeg: "8.1"
+            ffmpeg-features: "--features ffmpeg-sys-next/build"
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            ffmpeg: "7.1"
             ffmpeg-features: ""
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +110,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/ffmpeg71
-          key: ${{ runner.os }}-ffmpeg71-shared-v1
+          key: ${{ runner.os }}-${{ runner.arch }}-ffmpeg71-shared-v1
 
       - name: Build FFmpeg 7.1 from source (if not cached)
         if: matrix.ffmpeg == '7.1'
@@ -118,7 +138,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build
         run: cargo build --all-features ${{ matrix.ffmpeg-features }} --verbose
@@ -143,15 +163,27 @@ jobs:
         run: cargo clippy --all-features ${{ matrix.ffmpeg-features }} --lib
 
   test:
-    name: Test (FFmpeg ${{ matrix.ffmpeg }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.arch }}, FFmpeg ${{ matrix.ffmpeg }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - ffmpeg: "8.1"
+          - runner: ubuntu-24.04
+            arch: x64
+            ffmpeg: "8.1"
             ffmpeg-features: "--features ffmpeg-sys-next/build"
-          - ffmpeg: "7.1"
+          - runner: ubuntu-24.04
+            arch: x64
+            ffmpeg: "7.1"
+            ffmpeg-features: ""
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            ffmpeg: "8.1"
+            ffmpeg-features: "--features ffmpeg-sys-next/build"
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            ffmpeg: "7.1"
             ffmpeg-features: ""
     # Runs the full library suite MINUS the opengl feature, whose tests need a
     # GPU/display (surfman connection creation fails headless). The wgpu
@@ -175,7 +207,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/ffmpeg71
-          key: ${{ runner.os }}-ffmpeg71-shared-v1
+          key: ${{ runner.os }}-${{ runner.arch }}-ffmpeg71-shared-v1
 
       - name: Build FFmpeg 7.1 from source (if not cached)
         if: matrix.ffmpeg == '7.1'
@@ -203,14 +235,128 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-test-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Test
         run: cargo test --lib --features async,rtmp,flv,subtitle,wgpu ${{ matrix.ffmpeg-features }}
 
+  platform:
+    name: Platform (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            platform: macos-15-arm64
+            os: macos
+            target: aarch64-apple-darwin
+            build_features: ffmpeg-sys-next/build-videotoolbox,async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: ffmpeg-sys-next/build-videotoolbox,async,rtmp,flv,subtitle,wgpu
+          - runner: windows-2025
+            platform: windows-2025-x64
+            os: windows
+            target: x86_64-pc-windows-msvc
+            vcpkg_triplet: x64-windows
+            build_features: async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: async,rtmp,flv,subtitle,wgpu
+          - runner: windows-11-arm
+            platform: windows-11-arm64
+            os: windows
+            target: aarch64-pc-windows-msvc
+            vcpkg_triplet: arm64-windows
+            build_features: async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: async,rtmp,flv,subtitle,wgpu
+    env:
+      CARGO_BUILD_JOBS: 2
+      CARGO_INCREMENTAL: 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify native Rust target
+        shell: bash
+        run: |
+          rustc -vV
+          test "$(rustc -vV | sed -n 's/^host: //p')" = "${{ matrix.target }}"
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-platform-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Configure vcpkg
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $root = $env:VCPKG_INSTALLATION_ROOT
+          $cache = Join-Path $env:GITHUB_WORKSPACE "vcpkg-bincache"
+          New-Item -ItemType Directory -Force -Path $cache | Out-Null
+          "VCPKG_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKG_DEFAULT_TRIPLET=${{ matrix.vcpkg_triplet }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKGRS_TRIPLET=${{ matrix.vcpkg_triplet }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKG_DEFAULT_BINARY_CACHE=$cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$root\installed\${{ matrix.vcpkg_triplet }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Cache vcpkg binary packages
+        if: matrix.os == 'windows'
+        uses: actions/cache@v4
+        with:
+          path: vcpkg-bincache
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-b5229343-ffmpeg-8.1.2-v1
+
+      - name: Install FFmpeg 8.1 with vcpkg
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory $env:VCPKG_ROOT
+          if ($LASTEXITCODE -ne 0) { throw "git config exited with code $LASTEXITCODE" }
+          git -C $env:VCPKG_ROOT fetch --depth=1 origin b5229343b4b80264ed51e89c6a7dcd0cbe85e9cc
+          if ($LASTEXITCODE -ne 0) { throw "git fetch exited with code $LASTEXITCODE" }
+          git -C $env:VCPKG_ROOT checkout --force FETCH_HEAD
+          if ($LASTEXITCODE -ne 0) { throw "git checkout exited with code $LASTEXITCODE" }
+          & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
+          if ($LASTEXITCODE -ne 0) { throw "bootstrap-vcpkg exited with code $LASTEXITCODE" }
+          & "$env:VCPKG_ROOT\vcpkg.exe" install "ffmpeg:${{ matrix.vcpkg_triplet }}" --clean-after-build
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg install exited with code $LASTEXITCODE" }
+          $ffmpeg = & "$env:VCPKG_ROOT\vcpkg.exe" list | Select-String "^ffmpeg:"
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg list exited with code $LASTEXITCODE" }
+          if (-not $ffmpeg) { throw "The FFmpeg vcpkg package was not installed" }
+          $ffmpeg
+
+      # The crate-level `static` feature is intentionally omitted on Windows:
+      # these vcpkg triplets provide shared FFmpeg libraries. macOS uses the
+      # dependency's source-build feature directly. Every functional optional
+      # feature is type-checked on each native platform.
+      - name: Build all non-static features
+        run: cargo build --features "${{ matrix.build_features }}" --verbose
+
+      - name: Build all non-static feature tests
+        run: cargo test --lib --features "${{ matrix.build_features }}" --no-run
+
+      - name: Build default features on Windows
+        if: matrix.os == 'windows'
+        run: cargo build --verbose
+
+      - name: Build default crate features with source FFmpeg on macOS
+        if: matrix.os == 'macos'
+        run: cargo build --features ffmpeg-sys-next/build --verbose
+
+      # GPU-dependent features are compile-only above. This run exercises the
+      # platform scheduler, device, socket, RTMP, subtitle, and async paths.
+      - name: Run CPU-only library tests
+        run: cargo test --lib --features "${{ matrix.test_features }}"
+
   docs:
     name: Docs (docsrs cfg compile)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -229,7 +375,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
 
       # `DOCS_RS=1` makes ez-ffmpeg's build.rs pass `--cfg docsrs`, compiling its FFI
       # call sites as stubs; this gate catches a docsrs-stub compile gap (a fn that
@@ -247,7 +393,8 @@ jobs:
 
   asan:
     name: ASAN (UAF, FFmpeg 8.1)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -266,7 +413,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-asan-${{ hashFiles('**/Cargo.toml') }}
 
       # `-Zsanitizer=address` instruments the target crates' Rust code. The explicit
       # `--target` scopes the sanitizer to those crates and off the host build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Build default crate features with source FFmpeg on macOS
         if: matrix.os == 'macos'
-        run: cargo build --features ffmpeg-sys-next/build --verbose
+        run: cargo build --features ffmpeg-sys-next/build-videotoolbox --verbose
 
       # GPU-dependent features are compile-only above. This run exercises the
       # platform scheduler, device, socket, RTMP, subtitle, and async paths.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,10 @@ jobs:
             target: aarch64-apple-darwin
             build_features: ffmpeg-sys-next/build-videotoolbox,async,opengl,wgpu,rtmp,flv,subtitle
             test_features: ffmpeg-sys-next/build-videotoolbox,async,rtmp,flv,subtitle,wgpu
+            test_args: >-
+              --
+              --skip core::scheduler::ffmpeg_scheduler::tests::test_hwaccel
+              --skip core::scheduler::ffmpeg_scheduler::tests::test_to_stdout
           - runner: windows-2025
             platform: windows-2025-x64
             os: windows
@@ -261,6 +265,7 @@ jobs:
             vcpkg_triplet: x64-windows
             build_features: async,opengl,wgpu,rtmp,flv,subtitle
             test_features: async,rtmp,flv,subtitle,wgpu
+            test_args: ""
           - runner: windows-11-arm
             platform: windows-11-arm64
             os: windows
@@ -268,6 +273,7 @@ jobs:
             vcpkg_triplet: arm64-windows
             build_features: async,opengl,wgpu,rtmp,flv,subtitle
             test_features: async,rtmp,flv,subtitle,wgpu
+            test_args: ""
     env:
       CARGO_BUILD_JOBS: 2
       CARGO_INCREMENTAL: 0
@@ -349,10 +355,12 @@ jobs:
         if: matrix.os == 'macos'
         run: cargo build --features ffmpeg-sys-next/build-videotoolbox --verbose
 
-      # GPU-dependent features are compile-only above. This run exercises the
-      # platform scheduler, device, socket, RTMP, subtitle, and async paths.
+      # GPU-dependent features are compile-only above. GitHub's macOS runner
+      # also cannot create a VideoToolbox compression session, so its two
+      # hardware-encoder tests stay compile-only. The remaining suite exercises
+      # the platform scheduler, device, socket, RTMP, subtitle, and async paths.
       - name: Run CPU-only library tests
-        run: cargo test --lib --features "${{ matrix.test_features }}"
+        run: cargo test --lib --features "${{ matrix.test_features }}" ${{ matrix.test_args }}
 
   docs:
     name: Docs (docsrs cfg compile)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@
 #
 # Ubuntu's apt FFmpeg (6.1 on 24.04) matches neither lane, so it is never
 # installed; the apt packages below are just the FFmpeg build toolchain
-# (nasm/yasm/clang/pkg-config/zlib). First build per lane compiles FFmpeg
-# (~10-20 min); caches make subsequent runs fast.
+# (nasm/yasm/clang/pkg-config/zlib). The 7.1 install is cached; the 8.1 lane
+# rebuilds FFmpeg per job because its source-build helper tunes for the current
+# runner CPU.
+#
+# Cargo caches deliberately keep only registry and git sources, never `target`.
+# ffmpeg-sys-next's native source build adds `-march=native -mtune=native`, and
+# GitHub can schedule the same runner architecture on different CPU generations;
+# restoring those compiled artifacts can otherwise terminate tests with SIGILL.
 #
 # Native platform coverage outside Linux runs once per GitHub-hosted
 # architecture: Apple Silicon macOS, Windows x64, and Windows ARM64. macOS
@@ -131,14 +137,13 @@ jobs:
           echo "PKG_CONFIG_PATH=$HOME/ffmpeg71/lib/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$HOME/ffmpeg71/lib" >> "$GITHUB_ENV"
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo sources
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build
         run: cargo build --all-features ${{ matrix.ffmpeg-features }} --verbose
@@ -228,14 +233,13 @@ jobs:
           echo "PKG_CONFIG_PATH=$HOME/ffmpeg71/lib/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$HOME/ffmpeg71/lib" >> "$GITHUB_ENV"
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo sources
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-test-ffmpeg${{ matrix.ffmpeg }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Test
         run: cargo test --lib --features async,rtmp,flv,subtitle,wgpu ${{ matrix.ffmpeg-features }}
@@ -288,14 +292,13 @@ jobs:
           rustc -vV
           test "$(rustc -vV | sed -n 's/^host: //p')" = "${{ matrix.target }}"
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo sources
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-platform-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Configure vcpkg
         if: matrix.os == 'windows'
@@ -376,14 +379,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo sources
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
       # `DOCS_RS=1` makes ez-ffmpeg's build.rs pass `--cfg docsrs`, compiling its FFI
       # call sites as stubs; this gate catches a docsrs-stub compile gap (a fn that
@@ -414,14 +416,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo sources
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-asan-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
       # `-Zsanitizer=address` instruments the target crates' Rust code. The explicit
       # `--target` scopes the sanitizer to those crates and off the host build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             ffmpeg: "7.1"
             ffmpeg-features: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install FFmpeg build toolchain
         run: |
@@ -107,7 +107,7 @@ jobs:
 
       - name: Cache FFmpeg 7.1 install
         if: matrix.ffmpeg == '7.1'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/ffmpeg71
           key: ${{ runner.os }}-${{ runner.arch }}-ffmpeg71-shared-v1
@@ -132,7 +132,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$HOME/ffmpeg71/lib" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -192,7 +192,7 @@ jobs:
     # layout pins, builder checks — run for real. Media assets are committed
     # as test.mp4.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install FFmpeg build toolchain
         run: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: Cache FFmpeg 7.1 install
         if: matrix.ffmpeg == '7.1'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/ffmpeg71
           key: ${{ runner.os }}-${{ runner.arch }}-ffmpeg71-shared-v1
@@ -229,7 +229,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$HOME/ffmpeg71/lib" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -278,7 +278,7 @@ jobs:
       CARGO_BUILD_JOBS: 2
       CARGO_INCREMENTAL: 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -289,7 +289,7 @@ jobs:
           test "$(rustc -vV | sed -n 's/^host: //p')" = "${{ matrix.target }}"
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -313,7 +313,7 @@ jobs:
 
       - name: Cache vcpkg binary packages
         if: matrix.os == 'windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: vcpkg-bincache
           key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-b5229343-ffmpeg-8.1.2-v1
@@ -366,7 +366,7 @@ jobs:
     name: Docs (docsrs cfg compile)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install FFmpeg build toolchain
         run: |
@@ -377,7 +377,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install FFmpeg build toolchain
         run: |
@@ -415,7 +415,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/src/core/metadata/default_behavior.rs
+++ b/src/core/metadata/default_behavior.rs
@@ -74,25 +74,25 @@ pub unsafe fn copy_metadata_default(
         // These keys are typically encoder/software specific and shouldn't be copied
         av_dict_set(
             &mut output_ref.metadata,
-            b"creation_time\0".as_ptr() as *const i8,
+            b"creation_time\0".as_ptr() as *const std::os::raw::c_char,
             std::ptr::null(),
             0,
         );
         av_dict_set(
             &mut output_ref.metadata,
-            b"company_name\0".as_ptr() as *const i8,
+            b"company_name\0".as_ptr() as *const std::os::raw::c_char,
             std::ptr::null(),
             0,
         );
         av_dict_set(
             &mut output_ref.metadata,
-            b"product_name\0".as_ptr() as *const i8,
+            b"product_name\0".as_ptr() as *const std::os::raw::c_char,
             std::ptr::null(),
             0,
         );
         av_dict_set(
             &mut output_ref.metadata,
-            b"product_version\0".as_ptr() as *const i8,
+            b"product_version\0".as_ptr() as *const std::os::raw::c_char,
             std::ptr::null(),
             0,
         );
@@ -101,7 +101,7 @@ pub unsafe fn copy_metadata_default(
         if recording_time_set {
             av_dict_set(
                 &mut output_ref.metadata,
-                b"duration\0".as_ptr() as *const i8,
+                b"duration\0".as_ptr() as *const std::os::raw::c_char,
                 std::ptr::null(),
                 0,
             );
@@ -166,7 +166,7 @@ pub unsafe fn copy_metadata_default(
             if encoding_streams.contains(&output_idx) {
                 av_dict_set(
                     &mut output_stream.metadata,
-                    b"encoder\0".as_ptr() as *const i8,
+                    b"encoder\0".as_ptr() as *const std::os::raw::c_char,
                     std::ptr::null(),
                     0,
                 );

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -487,9 +487,40 @@ extern "C" fn cleanup() {
     });
 }
 
-// Use the exact target ABI emitted by ffmpeg-sys-next for the same bindings as
-// av_log_set_callback and av_log_format_line. Keeping a second architecture
-// table here would drift whenever bindgen changes a platform's va_list layout.
+// C adjusts an array-typed `va_list` parameter to a pointer. Bindgen preserves
+// that adjustment in FFmpeg's function signatures, while its public `va_list`
+// alias remains the original one-element array. Extract the generated element
+// type so the callback follows the same ABI without naming bindgen internals.
+#[cfg(any(
+    all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)),
+    target_arch = "s390x",
+    all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)),
+))]
+trait VaListArray {
+    type Element;
+}
+
+#[cfg(any(
+    all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)),
+    target_arch = "s390x",
+    all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)),
+))]
+impl<T, const N: usize> VaListArray for [T; N] {
+    type Element = T;
+}
+
+#[cfg(any(
+    all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)),
+    target_arch = "s390x",
+    all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)),
+))]
+type VaListType = *mut <ffmpeg_sys_next::va_list as VaListArray>::Element;
+
+#[cfg(not(any(
+    all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)),
+    target_arch = "s390x",
+    all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)),
+)))]
 type VaListType = ffmpeg_sys_next::va_list;
 
 /// Log target used for every message forwarded from FFmpeg, so applications

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -514,7 +514,7 @@ type VaListType = *mut ffmpeg_sys_next::__va_list_tag;
     not(target_os = "uefi"),
     not(windows),
 ))]
-type VaListType = *mut libc::c_void;
+type VaListType = ffmpeg_sys_next::__BindgenOpaqueArray<u64, 4>;
 
 #[cfg(all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)))]
 type VaListType = *mut ffmpeg_sys_next::__va_list_tag_powerpc;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -487,40 +487,10 @@ extern "C" fn cleanup() {
     });
 }
 
-// The following type definitions for `VaListType` are inspired by the Rust standard library's
-// implementation of `va_list` (see std::ffi::va_list::VaListImpl). These definitions ensure compatibility
-// with platform-specific ABI requirements when interfacing with C variadic functions.
-
-#[cfg(any(
-    all(
-        not(target_arch = "aarch64"),
-        not(target_arch = "powerpc"),
-        not(target_arch = "s390x"),
-        not(target_arch = "x86_64")
-    ),
-    all(target_arch = "aarch64", target_vendor = "apple"),
-    target_family = "wasm",
-    target_os = "uefi",
-    windows,
-))]
-type VaListType = *mut libc::c_char;
-
-#[cfg(all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)))]
-type VaListType = *mut ffmpeg_sys_next::__va_list_tag;
-
-#[cfg(all(
-    target_arch = "aarch64",
-    not(target_vendor = "apple"),
-    not(target_os = "uefi"),
-    not(windows),
-))]
-type VaListType = ffmpeg_sys_next::__BindgenOpaqueArray<u64, 4>;
-
-#[cfg(all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)))]
-type VaListType = *mut ffmpeg_sys_next::__va_list_tag_powerpc;
-
-#[cfg(target_arch = "s390x")]
-type VaListType = *mut ffmpeg_sys_next::__va_list_tag_s390x;
+// Use the exact target ABI emitted by ffmpeg-sys-next for the same bindings as
+// av_log_set_callback and av_log_format_line. Keeping a second architecture
+// table here would drift whenever bindgen changes a platform's va_list layout.
+type VaListType = ffmpeg_sys_next::va_list;
 
 /// Log target used for every message forwarded from FFmpeg, so applications
 /// can tune FFmpeg's verbosity independently of ez-ffmpeg's own logs,


### PR DESCRIPTION
## Problem

ez-ffmpeg fails to compile on aarch64-unknown-linux-gnu (e.g., RK3568/RK3588 ARM64 Linux) with 8 errors:

1. 6x type mismatch in av_dict_set calls - *const i8 vs *const u8 because AArch64 Linux defines char as unsigned (u8) unlike x86_64 (i8)
2. 1x va_list opaque array mismatch - AArch64 AAPCS represents va_list as __BindgenOpaqueArray<u64, 4>, not *mut c_void
3. 1x callback signature mismatch - av_log_set_callback expects the 4th parameter matching the architecture va_list type

## Changes

### src/core/metadata/default_behavior.rs
Replace 6 occurrences of s *const i8 with s *const std::os::raw::c_char.

### src/core/mod.rs
Change the aarch64 VaListType from *mut libc::c_void to fmpeg_sys_next::__BindgenOpaqueArray<u64, 4>, matching the actual va_list representation generated by bindgen on AArch64 Linux.

## Verification

- Cross-compiled successfully for aarch64-unknown-linux-gnu with FFmpeg 7.1
- Verified that workspace members depending on ez-ffmpeg build cleanly
- x86_64 build continues to work (tested on Windows)