### PR TITLE
fix(scheduler): preserve mux stream identity before balancing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,9 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           HOMEBREW_NO_INSTALL_CLEANUP: "1"
         run: |
+          # GitHub's image may carry an unrelated untrusted aws/tap. Remove it
+          # before Homebrew runs diagnostics so the job stays annotation-free.
+          brew untap aws/tap >/dev/null 2>&1 || true
           brew install ffmpeg@7
           prefix="$(brew --prefix ffmpeg@7)"
           version="$("$prefix/bin/ffmpeg" -version | sed -n 's/^ffmpeg version \([^ ]*\).*/\1/p')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,11 @@
 # GitHub can schedule the same runner architecture on different CPU generations;
 # restoring those compiled artifacts can otherwise terminate tests with SIGILL.
 #
-# Native platform coverage outside Linux runs once per GitHub-hosted
-# architecture: Apple Silicon macOS, Windows x64, and Windows ARM64. macOS
-# builds FFmpeg 8.1 from source, while Windows installs FFmpeg 8.1 through the
-# runner's vcpkg checkout. These jobs build every functional non-static feature,
+# Native platform coverage outside Linux runs both FFmpeg lanes on every
+# GitHub-hosted architecture: Apple Silicon macOS, Windows x64, and Windows
+# ARM64. macOS builds FFmpeg 8.1 from source and uses Homebrew's versioned
+# FFmpeg 7 formula; Windows checks out pinned vcpkg revisions whose ports carry
+# FFmpeg 8.1.2 and 7.1.2. These jobs build every functional non-static feature,
 # compile the corresponding test trees, and run the CPU-only library suite.
 #
 # GPU-dependent code: the `opengl` frame filter needs a real GPU/display and
@@ -245,7 +246,7 @@ jobs:
         run: cargo test --lib --features async,rtmp,flv,subtitle,wgpu ${{ matrix.ffmpeg-features }}
 
   platform:
-    name: Platform (${{ matrix.platform }})
+    name: Platform (${{ matrix.platform }}, FFmpeg ${{ matrix.ffmpeg }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
@@ -256,8 +257,22 @@ jobs:
             platform: macos-15-arm64
             os: macos
             target: aarch64-apple-darwin
+            ffmpeg: "8.1"
             build_features: ffmpeg-sys-next/build-videotoolbox,async,opengl,wgpu,rtmp,flv,subtitle
             test_features: ffmpeg-sys-next/build-videotoolbox,async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: --features ffmpeg-sys-next/build-videotoolbox
+            test_args: >-
+              --
+              --skip core::scheduler::ffmpeg_scheduler::tests::test_hwaccel
+              --skip core::scheduler::ffmpeg_scheduler::tests::test_to_stdout
+          - runner: macos-15
+            platform: macos-15-arm64
+            os: macos
+            target: aarch64-apple-darwin
+            ffmpeg: "7.1"
+            build_features: async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: ""
             test_args: >-
               --
               --skip core::scheduler::ffmpeg_scheduler::tests::test_hwaccel
@@ -266,17 +281,49 @@ jobs:
             platform: windows-2025-x64
             os: windows
             target: x86_64-pc-windows-msvc
+            ffmpeg: "8.1"
             vcpkg_triplet: x64-windows
+            vcpkg_ref: b5229343b4b80264ed51e89c6a7dcd0cbe85e9cc
+            vcpkg_cache: b5229343-ffmpeg-8.1.2-v1
             build_features: async,opengl,wgpu,rtmp,flv,subtitle
             test_features: async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: ""
+            test_args: ""
+          - runner: windows-2025
+            platform: windows-2025-x64
+            os: windows
+            target: x86_64-pc-windows-msvc
+            ffmpeg: "7.1"
+            vcpkg_triplet: x64-windows
+            vcpkg_ref: 6070d5cb2f818921c10ccdf6f35f3415a2503369
+            vcpkg_cache: 6070d5cb-ffmpeg-7.1.2-p5-v1
+            build_features: async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: ""
             test_args: ""
           - runner: windows-11-arm
             platform: windows-11-arm64
             os: windows
             target: aarch64-pc-windows-msvc
+            ffmpeg: "8.1"
             vcpkg_triplet: arm64-windows
+            vcpkg_ref: b5229343b4b80264ed51e89c6a7dcd0cbe85e9cc
+            vcpkg_cache: b5229343-ffmpeg-8.1.2-v1
             build_features: async,opengl,wgpu,rtmp,flv,subtitle
             test_features: async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: ""
+            test_args: -- --test-threads=1
+          - runner: windows-11-arm
+            platform: windows-11-arm64
+            os: windows
+            target: aarch64-pc-windows-msvc
+            ffmpeg: "7.1"
+            vcpkg_triplet: arm64-windows
+            vcpkg_ref: 6070d5cb2f818921c10ccdf6f35f3415a2503369
+            vcpkg_cache: 6070d5cb-ffmpeg-7.1.2-p5-v1
+            build_features: async,opengl,wgpu,rtmp,flv,subtitle
+            test_features: async,rtmp,flv,subtitle,wgpu
+            default_ffmpeg_features: ""
             test_args: -- --test-threads=1
     env:
       CARGO_BUILD_JOBS: 2
@@ -300,6 +347,27 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('**/Cargo.toml') }}
 
+      # ffmpeg@7 is keg-only and uses absolute Homebrew install names, so its
+      # shared libraries remain discoverable without DYLD_LIBRARY_PATH. The
+      # versioned formula tracks the latest 7.1 patch release.
+      - name: Install FFmpeg 7.1 with Homebrew
+        if: matrix.os == 'macos' && matrix.ffmpeg == '7.1'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          brew install ffmpeg@7
+          prefix="$(brew --prefix ffmpeg@7)"
+          version="$("$prefix/bin/ffmpeg" -version | sed -n 's/^ffmpeg version \([^ ]*\).*/\1/p')"
+          case "$version" in
+            7.1*) ;;
+            *) echo "Expected FFmpeg 7.1.x, found $version" >&2; exit 1 ;;
+          esac
+          echo "PKG_CONFIG_PATH=$prefix/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "$prefix/bin" >> "$GITHUB_PATH"
+          PKG_CONFIG_PATH="$prefix/lib/pkgconfig" pkg-config --modversion libavcodec
+
       - name: Configure vcpkg
         if: matrix.os == 'windows'
         shell: pwsh
@@ -319,15 +387,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg-bincache
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-b5229343-ffmpeg-8.1.2-v1
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-${{ matrix.vcpkg_cache }}
 
-      - name: Install FFmpeg 8.1 with vcpkg
+      - name: Install FFmpeg ${{ matrix.ffmpeg }} with vcpkg
         if: matrix.os == 'windows'
         shell: pwsh
         run: |
           git config --global --add safe.directory $env:VCPKG_ROOT
           if ($LASTEXITCODE -ne 0) { throw "git config exited with code $LASTEXITCODE" }
-          git -C $env:VCPKG_ROOT fetch --depth=1 origin b5229343b4b80264ed51e89c6a7dcd0cbe85e9cc
+          git -C $env:VCPKG_ROOT fetch --depth=1 origin ${{ matrix.vcpkg_ref }}
           if ($LASTEXITCODE -ne 0) { throw "git fetch exited with code $LASTEXITCODE" }
           git -C $env:VCPKG_ROOT checkout --force FETCH_HEAD
           if ($LASTEXITCODE -ne 0) { throw "git checkout exited with code $LASTEXITCODE" }
@@ -338,25 +406,28 @@ jobs:
           $ffmpeg = & "$env:VCPKG_ROOT\vcpkg.exe" list | Select-String "^ffmpeg:"
           if ($LASTEXITCODE -ne 0) { throw "vcpkg list exited with code $LASTEXITCODE" }
           if (-not $ffmpeg) { throw "The FFmpeg vcpkg package was not installed" }
+          $expectedVersion = [regex]::Escape("${{ matrix.ffmpeg }}")
+          if ("$ffmpeg" -notmatch "\s$expectedVersion\.") {
+            throw "Expected FFmpeg ${{ matrix.ffmpeg }}.x, found: $ffmpeg"
+          }
           $ffmpeg
 
       # The crate-level `static` feature is intentionally omitted on Windows:
       # these vcpkg triplets provide shared FFmpeg libraries. macOS uses the
-      # dependency's source-build feature directly. Every functional optional
-      # feature is type-checked on each native platform.
+      # dependency's source-build feature for 8.1 and Homebrew's shared 7.1
+      # libraries for the compatibility lane. Every functional optional feature
+      # is type-checked on each native platform.
       - name: Build all non-static features
         run: cargo build --features "${{ matrix.build_features }}" --verbose
 
       - name: Build all non-static feature tests
         run: cargo test --lib --features "${{ matrix.build_features }}" --no-run
 
-      - name: Build default features on Windows
-        if: matrix.os == 'windows'
-        run: cargo build --verbose
-
-      - name: Build default crate features with source FFmpeg on macOS
-        if: matrix.os == 'macos'
-        run: cargo build --features ffmpeg-sys-next/build-videotoolbox --verbose
+      # This keeps the crate's own default feature set empty while carrying only
+      # the dependency feature needed to provision source-built FFmpeg 8.1 on
+      # macOS. The system/vcpkg lanes pass an empty string here.
+      - name: Build default crate features
+        run: cargo build ${{ matrix.default_ffmpeg_features }} --verbose
 
       # GPU-dependent features are compile-only above. GitHub's macOS runner
       # also cannot create a VideoToolbox compression session, so its two

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 <div align="center">
 
+[![CI](https://github.com/YeautyYE/ez-ffmpeg/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/YeautyYE/ez-ffmpeg/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![Crates.io](https://img.shields.io/crates/v/ez-ffmpeg.svg)](https://crates.io/crates/ez-ffmpeg)
 [![Documentation](https://img.shields.io/badge/docs.rs-ez--ffmpeg-blue)](https://docs.rs/ez-ffmpeg)
 [![License: MIT/Apache-2.0/MPL-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0%2FMPL--2.0-brightgreen.svg)](https://github.com/YeautyYE/ez-ffmpeg/blob/main/LICENSE-APACHE)
-[![Rust](https://img.shields.io/badge/Rust-%3E=1.80.0-orange)](https://www.rust-lang.org/)
-[![FFmpeg](https://img.shields.io/badge/FFmpeg-7.0--8.x-blue)](https://ffmpeg.org)
 
 </div>
 
@@ -36,7 +35,17 @@ Not every CLI feature is implemented. Notable gaps (unsupported paths fail with 
 ## Version Requirements
 
 - **Rust:** Version 1.80.0 or higher.
-- **FFmpeg:** Version 7.0 through 8.x (one build links either major; the bindings gate on the installed version). 
+- **FFmpeg:** Version 7.0 through 8.x (one build links either major; the bindings gate on the installed version).
+
+### Continuously Tested Platforms
+
+The following native targets and FFmpeg versions are continuously tested by GitHub Actions. This matrix is not an exhaustive list of targets on which `ez-ffmpeg` may work.
+
+| Operating system | Rust targets tested in CI | FFmpeg versions |
+| --- | --- | --- |
+| Linux | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu` | 7.1, 8.1 |
+| macOS | `aarch64-apple-darwin` | 7.1, 8.1 |
+| Windows | `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc` | 7.1, 8.1 |
 
 ## Documentation
 

--- a/src/core/scheduler/enc_task.rs
+++ b/src/core/scheduler/enc_task.rs
@@ -2080,13 +2080,28 @@ pub(crate) enum SendToMuxError {
 /// `demux_task`, streamcopy destinations — fftools sends both through the same
 /// `sch_send` path (ffmpeg_sched.c:2038-2077).
 pub(crate) fn send_to_mux(
-    packet_box: PacketBox,
+    mut packet_box: PacketBox,
     pkt_sender: &Sender<PacketBox>,
     pre_pkt_sender: &PreMuxQueueSender,
     mux_start_gate: &Arc<crate::core::context::MuxStartGate>,
     scheduler_status: &Arc<AtomicUsize>,
     pause_epoch: &Arc<AtomicUsize>,
 ) -> Result<(), SendToMuxError> {
+    // avcodec_receive_packet leaves stream_index at the packet shell's default
+    // (normally 0). The mux worker uses that field for per-stream scheduling
+    // before write_packet later stamps it, so packets from encoded stream 1+
+    // would otherwise advance stream 0's DTS and could starve a finite input in
+    // the balancing pass. PacketData is the canonical destination carried by
+    // every encoder/copy path. Preserve a negative stream_index because it is
+    // the demux-side per-stream EOF sentinel.
+    // SAFETY: Packet owns a live AVPacket for the duration of this mutation.
+    unsafe {
+        let pkt = packet_box.packet.as_mut_ptr();
+        if (*pkt).stream_index >= 0 {
+            (*pkt).stream_index = packet_box.packet_data.output_stream_index;
+        }
+    }
+
     if mux_start_gate.is_started() {
         return pkt_sender
             .send(packet_box)
@@ -2241,12 +2256,15 @@ const PRE_MUX_FULL_WAIT_SLICE: Duration = Duration::from_millis(200);
 #[cfg(all(test, not(docsrs)))]
 mod tests {
     use super::should_cascade_break;
-    use super::{account_slice, park_pre_mux, SendToMuxError, PRE_MUX_FULL_WAIT_SLICE};
+    use super::{
+        account_slice, park_pre_mux, send_to_mux, SendToMuxError, PRE_MUX_FULL_WAIT_SLICE,
+    };
     use crate::core::context::pre_mux_queue::{channel, PreMuxQueueConfig, PreQueueTryPush};
     use crate::core::context::{MuxStartGate, PacketBox, PacketData};
     use crate::core::scheduler::ffmpeg_scheduler::{
         notify_pause_waiters, STATUS_END, STATUS_PAUSE, STATUS_RUN,
     };
+    use ffmpeg_next::packet::{Mut, Ref};
     use ffmpeg_sys_next::AVMediaType::AVMEDIA_TYPE_VIDEO;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -2293,6 +2311,41 @@ mod tests {
         // Not finished: never break for a cascade, regardless of opened.
         assert!(!should_cascade_break(false, false));
         assert!(!should_cascade_break(true, false));
+    }
+
+    // Real packets returned by avcodec_receive_packet keep the AVPacket shell's
+    // default stream_index (0). The mux worker reads stream_index before its
+    // write-time fixup, so the shared send boundary must stamp the canonical
+    // PacketData destination. A negative value is the demux EOF sentinel and
+    // must survive unchanged.
+    #[test]
+    fn send_to_mux_stamps_data_stream_index_and_preserves_eof() {
+        let (pre_tx, _pre_rx) = channel(park_test_cfg());
+        let gate = Arc::new(MuxStartGate::new());
+        gate.start_with(|| {});
+        let (pkt_tx, pkt_rx) = crossbeam_channel::bounded(2);
+        let status = Arc::new(AtomicUsize::new(STATUS_RUN));
+        let pause_epoch = Arc::new(AtomicUsize::new(0));
+
+        let mut data = park_test_packet(8);
+        data.packet_data.output_stream_index = 2;
+        // SAFETY: `data` owns this live packet shell exclusively.
+        unsafe {
+            (*data.packet.as_mut_ptr()).stream_index = 0;
+        }
+        assert!(send_to_mux(data, &pkt_tx, &pre_tx, &gate, &status, &pause_epoch).is_ok());
+        let data = pkt_rx.recv().unwrap();
+        assert_eq!(unsafe { (*data.packet.as_ptr()).stream_index }, 2);
+
+        let mut eof = park_test_packet(0);
+        eof.packet_data.output_stream_index = 2;
+        // SAFETY: `eof` owns this live packet shell exclusively.
+        unsafe {
+            (*eof.packet.as_mut_ptr()).stream_index = -1;
+        }
+        assert!(send_to_mux(eof, &pkt_tx, &pre_tx, &gate, &status, &pause_epoch).is_ok());
+        let eof = pkt_rx.recv().unwrap();
+        assert_eq!(unsafe { (*eof.packet.as_ptr()).stream_index }, -1);
     }
 
     // A full pre-mux queue whose deferred-start gate never opens and whose

--- a/tests/shortest.rs
+++ b/tests/shortest.rs
@@ -117,18 +117,21 @@ fn shortest_stops_infinite_video_at_short_audio() {
     );
 }
 
-/// Three encoded streams exercise the `sq_enc` cascade-cut path. Audio (2 s) is
+/// Three encoded streams exercise the `sq_enc` cascade-cut path. Audio (10 s) is
 /// the shortest; two INFINITE videos are both cascade-cut when it ends. With 3+
 /// streams, a cascade-cut stream that keeps its now-stale timestamp in the input
 /// balancer can choke a peer that another cascade-cut stream's drain is waiting
 /// on — a deadlock that a 2-stream job never hits (the sole other stream is
-/// always the trailing one). Both videos must be cut at ~2 s and the job must
+/// always the trailing one). Both videos must be cut at ~10 s and the job must
 /// terminate; a hang here means a cascade-cut stream never left the balancer.
 #[test]
 fn shortest_stops_three_streams_with_two_infinite_videos() {
     let out = tmp_path("shortest_three_streams.mp4");
     let scheduler = FfmpegContext::builder()
-        .input(lavfi_audio_secs(2))
+        // Long enough that input balancing starts before this synthetic source
+        // reaches EOF. With 2 s the demuxer can win the startup race and hide a
+        // bug that chokes the finite source mid-stream.
+        .input(lavfi_audio_secs(10))
         .input(lavfi_video_infinite())
         .input(lavfi_video_infinite())
         .output(
@@ -148,7 +151,7 @@ fn shortest_stops_three_streams_with_two_infinite_videos() {
     let result = wait_with_watchdog(scheduler, 60, "shortest stops three streams");
     assert!(result.is_ok(), "-shortest 3-stream job failed: {result:?}");
 
-    // Both infinite videos are cut at the 2 s audio bound. `find_video_stream_info`
+    // Both infinite videos are cut at the 10 s audio bound. `find_video_stream_info`
     // reports the first video; a bounded count (not thousands) proves the cut —
     // and termination at all proves BOTH infinite videos were stopped. The upper
     // bound is looser than the two-stream test: with three encoders competing for
@@ -157,8 +160,8 @@ fn shortest_stops_three_streams_with_two_infinite_videos() {
     // fails loudly on a real regression.
     let frames = video_nb_frames(&out);
     assert!(
-        (45..=120).contains(&frames),
-        "video should be truncated near the 2s audio bound, got {frames}"
+        (240..=390).contains(&frames),
+        "video should be truncated near the 10s audio bound, got {frames}"
     );
 }
 


### PR DESCRIPTION
## Summary

- stamp mux-bound packets with their canonical output stream index before scheduler bookkeeping
- strengthen the three-stream `-shortest` regression so input balancing starts before the finite source reaches EOF
- test FFmpeg 7.1 and 8.1 on Linux x64/ARM64, macOS ARM64, and Windows x64/ARM64
- add one live CI badge and a compact continuously-tested platform table to the README

## Root cause

`avcodec_receive_packet` leaves `AVPacket.stream_index` at the packet shell's default value. The mux worker used that field for per-stream DTS balancing before the later write path replaced it from `PacketData.output_stream_index`.

With audio as output stream 0 and two encoded videos as streams 1 and 2, video packets advanced the audio scheduler node while both video nodes stayed at DTS zero. The finite audio source then appeared too far ahead, remained choked before EOF, and the two infinite videos never received the `-shortest` cascade.

The shared `send_to_mux` boundary now stamps every nonnegative mux packet from `PacketData` while preserving the negative demux EOF sentinel.

## CI coverage

| OS | Architectures | FFmpeg |
|---|---|---|
| Linux | x86_64, AArch64 | 7.1, 8.1 |
| macOS | AArch64 | 7.1, 8.1 |
| Windows | x86_64, AArch64 | 7.1, 8.1 |

macOS 7.1 uses Homebrew `ffmpeg@7`. Windows uses version-specific pinned vcpkg revisions and cache keys.

## Local validation

- `enc_task` unit tests: 6/6 passed
- `shortest` integration tests: 10/10 passed
- revised three-stream regression: 200/200 iterations with FFmpeg 7.1
- revised three-stream regression: 200/200 iterations with FFmpeg 8.1
- FFmpeg 7.1 feature suite: 766 passed, 16 ignored
- FFmpeg 8.1 lifecycle/teardown/shortest suite: all passed
- clippy completed with only the existing warning backlog
- changed Rust files pass `rustfmt --check`
- workflow YAML syntax and `git diff --check` pass
