### PR TITLE
fix: use mem::zeroed() for AVBPrint init to support 32-bit architectures

### DIFF
--- a/src/core/scheduler/filter_task/config.rs
+++ b/src/core/scheduler/filter_task/config.rs
@@ -521,7 +521,7 @@ unsafe fn configure_output_audio_filter(
 
     // Use zeroed() instead of literal init so reserved_padding
     // matches the arch-dependent struct layout (32-bit vs 64-bit).
-    let mut bprint: AVBPrint = unsafe { std::mem::zeroed() };
+    let mut bprint: AVBPrint = std::mem::zeroed();
     av_bprint_init(&mut bprint, 0, u32::MAX);
 
     choose_sample_fmts(
@@ -857,7 +857,7 @@ unsafe fn configure_output_video_filter(
 
     // Use zeroed() instead of literal init so reserved_padding
     // matches the arch-dependent struct layout (32-bit vs 64-bit).
-    let mut bprint: AVBPrint = unsafe { std::mem::zeroed() };
+    let mut bprint: AVBPrint = std::mem::zeroed();
     av_bprint_init(&mut bprint, 0, u32::MAX);
 
     // Use user-specified format (via -pix_fmt) if set, otherwise use encoder-supported formats
@@ -1086,7 +1086,7 @@ unsafe fn configure_input_audio_filter(
 
     // Use zeroed() instead of literal init so reserved_padding
     // matches the arch-dependent struct layout (32-bit vs 64-bit).
-    let mut args: AVBPrint = unsafe { std::mem::zeroed() };
+    let mut args: AVBPrint = std::mem::zeroed();
 
     av_bprint_init(&mut args, 0, AV_BPRINT_SIZE_AUTOMATIC as u32);
     // Reject an invalid/unknown sample format instead of feeding a null into the

--- a/src/core/scheduler/filter_task/config.rs
+++ b/src/core/scheduler/filter_task/config.rs
@@ -519,14 +519,9 @@ unsafe fn configure_output_audio_filter(
     // removes the option entirely, and it was a no-op all along — fftools
     // n8.0 dropped the call.
 
-    let mut bprint = AVBPrint {
-        str_: null_mut(),
-        len: 0,
-        size: 0,
-        size_max: 0,
-        reserved_internal_buffer: [0; 1],
-        reserved_padding: [0; 1000],
-    };
+    // Use zeroed() instead of literal init so reserved_padding
+    // matches the arch-dependent struct layout (32-bit vs 64-bit).
+    let mut bprint: AVBPrint = unsafe { std::mem::zeroed() };
     av_bprint_init(&mut bprint, 0, u32::MAX);
 
     choose_sample_fmts(
@@ -860,14 +855,9 @@ unsafe fn configure_output_video_filter(
         return ret;
     }
 
-    let mut bprint = AVBPrint {
-        str_: null_mut(),
-        len: 0,
-        size: 0,
-        size_max: 0,
-        reserved_internal_buffer: [0; 1],
-        reserved_padding: [0; 1000],
-    };
+    // Use zeroed() instead of literal init so reserved_padding
+    // matches the arch-dependent struct layout (32-bit vs 64-bit).
+    let mut bprint: AVBPrint = unsafe { std::mem::zeroed() };
     av_bprint_init(&mut bprint, 0, u32::MAX);
 
     // Use user-specified format (via -pix_fmt) if set, otherwise use encoder-supported formats
@@ -1094,14 +1084,9 @@ unsafe fn configure_input_audio_filter(
     let abuffer_str = std::ffi::CString::new("abuffer").unwrap();
     let abuffer_filter = avfilter_get_by_name(abuffer_str.as_ptr());
 
-    let mut args = AVBPrint {
-        str_: null_mut(),
-        len: 0,
-        size: 0,
-        size_max: 0,
-        reserved_internal_buffer: [0; 1],
-        reserved_padding: [0; 1000],
-    };
+    // Use zeroed() instead of literal init so reserved_padding
+    // matches the arch-dependent struct layout (32-bit vs 64-bit).
+    let mut args: AVBPrint = unsafe { std::mem::zeroed() };
 
     av_bprint_init(&mut args, 0, AV_BPRINT_SIZE_AUTOMATIC as u32);
     // Reject an invalid/unknown sample format instead of feeding a null into the


### PR DESCRIPTION
The AVBPrint struct layout from ffmpeg-sys-next bindgen differs between 32-bit (ARMv7, i686) and 64-bit architectures due to pointer size and alignment differences. The hardcoded reserved_padding: [0; 1000] is correct for 64-bit but causes a size mismatch on 32-bit targets where the padding array is 1004 bytes.

Replace all three literal AVBPrint initializations with std::mem::zeroed() to let the compiler determine the correct layout for the target architecture.

Fixes compilation on armv7-unknown-linux-gnueabihf, i686-unknown-linux-gnu, and other 32-bit targets.